### PR TITLE
Fix "under the hood" typo.

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -29,7 +29,7 @@
     <div class="item description-paragraph">
       <h1 class="title">Open source</h1>
       <p class="body">
-        If you'd rather host this yourself or you just want to peek under the hook, go ahead and check out
+        If you'd rather host this yourself or you just want to peek under the hood, go ahead and check out
         <%= link_to "the source code for #{data.project.name}", data.project.github_url %>.
       </p>
     </div>


### PR DESCRIPTION
Unless, of course, "under the **hook**" is a _really_ subtle pun, in which case it should probably be in quotes. 😉 